### PR TITLE
Pass file to the render function

### DIFF
--- a/tasks/markdown-it.js
+++ b/tasks/markdown-it.js
@@ -67,7 +67,7 @@ module.exports = function(grunt) {
 
 
 			// parse markdown
-			html = md.render(src);
+			html = md.render(src, { file: f });
 
 			// write to destination
 			grunt.file.write(f.dest, html);


### PR DESCRIPTION
I noticed that the information about the file can be really useful when I was working with `markdown-it-replace-link` plugin.

                options: {
                    highlightjs: true,
                    html: true,
                    replaceLink: function (link, env) {
                        var linkObj = url.parse(link);
                        if (linkObj.protocol) {
                            return link;
                        } else {
                            linkObj = url.parse(
                                "http://stanislawswierc.github.io/"
                                + path.dirname(env.file.dest)
                                + '/'
                                + link.replace(/^\.?\//, ''))
                            return linkObj.href;
                        }
                    },
                    plugins: {
                        'markdown-it-anchor': {
                            level: 1
                        },
                        'markdown-it-replace-link': {},
                        'markdown-it-attrs': {},
                        'markdown-it-linkify-images': {}
                    }
                }